### PR TITLE
add funtionality to group labels.

### DIFF
--- a/data/label_grouping.yml
+++ b/data/label_grouping.yml
@@ -1,0 +1,23 @@
+---
+family_name_furigana: family_name
+family_name_furigana: family_name
+family_name_roma: family_name
+first_name_furigana: first_name
+first_name_roma: first_name
+user_name_furigana: user_name
+password_confirmation: password
+phone_number_first: phone_number
+phone_number_middle: phone_number
+phone_number_last: phone_number
+postal_code_first: postal_code
+postal_code_last: postal_code
+address_town: address
+address_street: address
+address_building: address
+birthday_year: birthday
+birthday_month: birthday
+birthday_day: birthday
+invite_code_first: invite_code
+invite_code_last: invite_last
+user_id_first: user_id
+user_id_middle: user_id

--- a/projects/bin/infer_test
+++ b/projects/bin/infer_test
@@ -1,11 +1,24 @@
 #!/usr/bin/env python
+import sys
+import os
+import yaml
 from semantic_selector import ml_model
 from semantic_selector import datasource
 
 
 def main():
+    '''
+        ./bin/infer_test [label grouping file]
+    '''
+    import yaml
+    label_grouping = None
+    if len(sys.argv) > 1 and os.path.exists(sys.argv[1]):
+        path = sys.argv[1]
+        with open(path) as f:
+            label_grouping = yaml.load(f.read())
+
     # training data is now auto loaded during LsiModel initialization
-    model = ml_model.LsiModel()
+    model = ml_model.LsiModel(grouping=label_grouping)
     input_tags = datasource.InputTags()
     test_records = input_tags.fetch_all('test_inputs')
 
@@ -13,8 +26,8 @@ def main():
     hit = 0
     for t in test_records:
         target_tag = t['html']
-        estimated_label = model.label_name(model.inference(target_tag))
-        correct_label = t['label']
+        estimated_label = model.grouped_label_name_from_id(model.inference(target_tag))
+        correct_label = model.grouped_label_name(t['label'])
         print(t['html'].replace(',', ' ') +
               ',' + estimated_label +
               "," + correct_label)

--- a/projects/bin/infer_test
+++ b/projects/bin/infer_test
@@ -26,7 +26,9 @@ def main():
     hit = 0
     for t in test_records:
         target_tag = t['html']
-        estimated_label = model.grouped_label_name_from_id(model.inference(target_tag))
+        estimated_label = model.grouped_label_name_from_id(
+                                    model.inference(target_tag)
+                                    )
         correct_label = model.grouped_label_name(t['label'])
         print(t['html'].replace(',', ' ') +
               ',' + estimated_label +

--- a/projects/semantic_selector/datasource.py
+++ b/projects/semantic_selector/datasource.py
@@ -10,7 +10,7 @@ class InputTags(object):
                             user='root',
                             password='',
                             host='localhost',
-                            database='login_form')
+                            database='register_form')
 
         def fetch_all(self, table_name):
             cursor = self.conn.cursor(dictionary=True)

--- a/projects/semantic_selector/ml_model.py
+++ b/projects/semantic_selector/ml_model.py
@@ -7,34 +7,35 @@ from semantic_selector import datasource
 
 class LsiModel(object):
 
-    def __init__(self):
-        self.num_topics = 15
+    def __init__(self, grouping=None):
+        self.num_topics = 25
         self.training_data_table = 'inputs'
         self.lr_solver = 'newton-cg'
         self.lr_max_iter = 10000
         self.lr_multi_class = 'ovr'
+        self.grouping = grouping
 
-        (answers, labels, label_types) = self.__fetch_training_data()
+        (answers, grouped_labels, grouped_label_types) = self.__fetch_training_data()
         self.answers = answers
-        self.label_types = label_types
-        self.label_ids = [self.label_id(x) for x in labels]
+        self.grouped_label_types = grouped_label_types
+        self.grouped_label_ids = [self.grouped_label_id(x) for x in grouped_labels]
 
         dictionary = corpora.Dictionary(self.answers)
         corpus = [dictionary.doc2bow(answer) for answer in self.answers]
         lsi = models.LsiModel(corpus,
-                              id2word=dictionary,
-                              num_topics=self.num_topics)
+                id2word=dictionary,
+                num_topics=self.num_topics)
 
         lsi_corpus_flattened = []
         for vec in lsi[corpus]:
             lsi_corpus_flattened.append(self.__sparse_to_dense(vec))
 
         lr = LogisticRegression(solver=self.lr_solver,
-                                max_iter=self.lr_max_iter,
-                                multi_class=self.lr_multi_class)
-        lr.fit(X=lsi_corpus_flattened, y=self.label_ids)
+                max_iter=self.lr_max_iter,
+                multi_class=self.lr_multi_class)
+        lr.fit(X=lsi_corpus_flattened, y=self.grouped_label_ids)
 
-        self.fitting_score = lr.score(X=lsi_corpus_flattened, y=self.label_ids)
+        self.fitting_score = lr.score(X=lsi_corpus_flattened, y=self.grouped_label_ids)
         self.dictionary = dictionary
         self.corpus = corpus
         self.lsi = lsi
@@ -47,11 +48,21 @@ class LsiModel(object):
         vec_lsi = self.__sparse_to_dense(self.lsi[vec_bow])
         return self.lr.predict([vec_lsi])[0]
 
-    def label_id(self, label_name):
-        return self.label_types.index(label_name)
+    def grouped_label_id(self, label_name):
+        grouped_label_name = self.grouped_label_name(label_name)
+        return self.grouped_label_types.index(grouped_label_name)
 
-    def label_name(self, label_id):
-        return self.label_types[label_id]
+    def grouped_label_name_from_id(self, label_id):
+        return self.grouped_label_types[label_id]
+
+    def grouped_label_name(self, label_name):
+        if not self.grouping:
+            return label_name
+        else:
+            if label_name in self.grouping:
+                return self.grouping[label_name]
+            else:
+                return label_name
 
     def __sparse_to_dense(self, vec):
         ret = [e[1] for e in vec]
@@ -67,8 +78,9 @@ class LsiModel(object):
             words = input_tag_tokenizer.get_attrs_value(r['html'])
             answers.append(words)
             labels.append(r['label'])
-        label_types = list(set(labels))
-        return (answers, labels, label_types)
+        grouped_labels = [self.grouped_label_name(l) for l in labels]
+        grouped_label_types = list(set(grouped_labels))
+        return (answers, labels, grouped_label_types)
 
 
 if __name__ == "__main__":

--- a/projects/semantic_selector/ml_model.py
+++ b/projects/semantic_selector/ml_model.py
@@ -15,27 +15,32 @@ class LsiModel(object):
         self.lr_multi_class = 'ovr'
         self.grouping = grouping
 
-        (answers, grouped_labels, grouped_label_types) = self.__fetch_training_data()
+        (answers,
+         grouped_labels,
+         grouped_label_types) = self.__fetch_training_data()
         self.answers = answers
         self.grouped_label_types = grouped_label_types
-        self.grouped_label_ids = [self.grouped_label_id(x) for x in grouped_labels]
+        self.grouped_label_ids = [
+                self.grouped_label_id(x) for x in grouped_labels
+                ]
 
         dictionary = corpora.Dictionary(self.answers)
         corpus = [dictionary.doc2bow(answer) for answer in self.answers]
         lsi = models.LsiModel(corpus,
-                id2word=dictionary,
-                num_topics=self.num_topics)
+                              id2word=dictionary,
+                              num_topics=self.num_topics)
 
         lsi_corpus_flattened = []
         for vec in lsi[corpus]:
             lsi_corpus_flattened.append(self.__sparse_to_dense(vec))
 
         lr = LogisticRegression(solver=self.lr_solver,
-                max_iter=self.lr_max_iter,
-                multi_class=self.lr_multi_class)
+                                max_iter=self.lr_max_iter,
+                                multi_class=self.lr_multi_class)
         lr.fit(X=lsi_corpus_flattened, y=self.grouped_label_ids)
 
-        self.fitting_score = lr.score(X=lsi_corpus_flattened, y=self.grouped_label_ids)
+        self.fitting_score = lr.score(X=lsi_corpus_flattened,
+                                      y=self.grouped_label_ids)
         self.dictionary = dictionary
         self.corpus = corpus
         self.lsi = lsi


### PR DESCRIPTION
学習データのラベル付にはラベル付け担当者による恣意性がある。

ラベル付け時には出来る限り細かいラベルをつけるべきだが、実応用時にはもう少しゆるいグルーピングで事足りるケースもあるはずなので、学習・推定時に複数のラベルを単一のラベルとして扱える機能を追加。