### PR TITLE
update sql query to exclude labels with few records.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,20 +22,20 @@ pip3 install -r projects/requirements.txt
 # Inference
 
 ```bash
-$ PYTHONPATH=projects  ./projects/bin/infer_test
+$ PYTHONPATH=projects  ./projects/bin/infer_test --threashold 10 --ratio_test 0.05
 failing inferences
 
 estimated, correct
-address_street,address_building
+family_name,address_town
 ...
-birthday_month,month
+address_town,address_street
 
 # of test data: 154
-# of training_data: 3358
+# of training_data: 3108
 # of vector elements: 500
-Model Fitting Score, 0.868969624777
-Accuracy, 0.7012987012987013
-Recall, 0.7012987012987013
+Model Fitting Score, 0.90444015444
+Accuracy, 0.7987012987012987
+Recall, 0.7987012987012987
 unkown ratio in test data, 0.0
 ```
 

--- a/projects/bin/infer_test
+++ b/projects/bin/infer_test
@@ -2,8 +2,10 @@
 import sys
 import os
 import yaml
+import argparse
 from semantic_selector import ml_model
 from semantic_selector import datasource
+
 
 
 def main():
@@ -11,7 +13,12 @@ def main():
         ./bin/infer_test
     '''
 
-    (training, tests) = datasource.InputTags(10).fetch_data(0.05)
+    parser = argparse.ArgumentParser(description='')
+    parser.add_argument('--threashold', type=int, nargs='?', help='a threashold of the number of labels', default=10)
+    parser.add_argument('--ratio_test', type=float, nargs='?', help='a ratio of test sets', default=0.05)
+    args = parser.parse_args()
+
+    (training, tests) = datasource.InputTags(args.threashold).fetch_data(args.ratio_test)
     model = ml_model.LsiModel(training)
     print("failing inferences\n")
     print("estimated, correct")

--- a/projects/bin/infer_test
+++ b/projects/bin/infer_test
@@ -11,7 +11,7 @@ def main():
         ./bin/infer_test
     '''
 
-    (training, tests) = datasource.InputTags().fetch_data(0.05)
+    (training, tests) = datasource.InputTags(10).fetch_data(0.05)
     model = ml_model.LsiModel(training)
     print("failing inferences\n")
     print("estimated, correct")

--- a/projects/semantic_selector/datasource.py
+++ b/projects/semantic_selector/datasource.py
@@ -39,11 +39,14 @@ class InputTags(object):
             test_data = []
             sql = '''
             select * from inputs
-                         where label IN
-                         (select label from inputs group by label having count(1) > :threshold)
-                         order by id
+                     where label IN
+                     (select label from inputs
+                                   group by label
+                                   having count(1) > :threshold)
+                     order by id
 '''
-            for r in self.session.execute(sql, { 'threshold' : self.exclude_threshold }):
+            vals = {'threshold': self.exclude_threshold}
+            for r in self.session.execute(sql, vals):
                 rand = random.randint(0, 100)
                 if (rand < 100 * ratio_test_data):
                     test_data.append(r)


### PR DESCRIPTION
トレーニングセット中のレコード数が一定未満のデータをトレーニングおよび評価対象から外します。

- デフォルトの足切り値は10です
- InputTags(exclude_threashold)のように、InputTagsのconstructorで足切りに用いる値を制御できます. 0を指定すれば今までと同様です。