### PR TITLE
feature: add mechanism to exclude based on url or topic

### DIFF
--- a/projects/docs/canonicalTopics.csv
+++ b/projects/docs/canonicalTopics.csv
@@ -1,6 +1,6 @@
 mail_delivery,mailSubscriptionCheck
 gender,gender
-questionnaire,question
+questionnaire,exclude
 pc_email,email
 other,unknown
 password,password

--- a/projects/docs/canonicalTopics.csv
+++ b/projects/docs/canonicalTopics.csv
@@ -40,12 +40,12 @@ user_name_furigana,userName
 postal_delivery,mailSubscriptionCheck
 company_department,unknown
 country,address-country
-nickname,nickname
+nickname,userName
 payment_type,unknown
 tel_type,unknown
 privacy_policy,serviceTermCheck
-security_question,securityQuestion
-security_answer,securityAnswer
+security_question,unknown
+security_answer,unknown
 search_button,unknown
 postal_code_search,postalCodeSearchButton
 back_button,backButton

--- a/projects/docs/canonicalTopics.csv
+++ b/projects/docs/canonicalTopics.csv
@@ -35,7 +35,7 @@ user_name,userName
 birthday,birthDate
 company_name,unknown
 user_type,unknown
-search_window,unknown
+search_window,searchWindow
 user_name_furigana,userName
 postal_delivery,mailSubscriptionCheck
 company_department,unknown
@@ -46,7 +46,7 @@ tel_type,unknown
 privacy_policy,serviceTermCheck
 security_question,unknown
 security_answer,unknown
-search_button,unknown
+search_button,searchButton
 postal_code_search,postalCodeSearchButton
 back_button,backButton
 mail_format,unknown

--- a/projects/semantic_selector/estimator/base.py
+++ b/projects/semantic_selector/estimator/base.py
@@ -54,6 +54,7 @@ class BaseEstimator(metaclass=ABCMeta):
             print("Accuracy Per Url")
             sample_url_n = {}
             correct_url_n = {}
+            acc_url = {}
             for (x, y, m) in zip(x_test, y_test, meta_test):
                 url = m.url
                 if url not in sample_url_n:
@@ -65,11 +66,12 @@ class BaseEstimator(metaclass=ABCMeta):
                     correct_url_n[url] += 1
                 sample_url_n[url] += 1
             for url in sample_url_n:
-                acc = float(correct_url_n[url]) / float(sample_url_n[url])
-                print("    {}: {:1.5f}({}/{})".format(url[:20],
-                                                      acc,
-                                                      correct_url_n[url],
-                                                      sample_url_n[url]))
+                acc_url[url] = float(correct_url_n[url]) / sample_url_n[url]
+            for url, acc in sorted(acc_url.items(), key=lambda x: -x[1]):
+                print("    {:110}: {:1.5f}({}/{})".format(url.split('?')[0],
+                                                          acc,
+                                                          correct_url_n[url],
+                                                          sample_url_n[url]))
 
         return (float(correct_n) / float(sample_n))
 

--- a/projects/semantic_selector/estimator/base.py
+++ b/projects/semantic_selector/estimator/base.py
@@ -73,6 +73,28 @@ class BaseEstimator(metaclass=ABCMeta):
                                                           correct_url_n[url],
                                                           sample_url_n[url]))
 
+            print("Accuracy Per Topic")
+            sample_tp_n = {}
+            correct_tp_n = {}
+            acc_tp = {}
+            for (x, y, m) in zip(x_test, y_test, meta_test):
+                tp = m.topic
+                if tp not in sample_tp_n:
+                    sample_tp_n[tp] = 0
+                if tp not in correct_tp_n:
+                    correct_tp_n[tp] = 0
+                prediction = self.predict_x(x)
+                if (prediction == y):
+                    correct_tp_n[tp] += 1
+                sample_tp_n[tp] += 1
+            for tp in sample_tp_n:
+                acc_tp[tp] = float(correct_tp_n[tp]) / sample_tp_n[tp]
+            for tp, acc in sorted(acc_tp.items(), key=lambda x: -x[1]):
+                print("    {:110}: {:1.5f}({}/{})".format(tp.split('?')[0],
+                                                          acc,
+                                                          correct_tp_n[tp],
+                                                          sample_tp_n[tp]))
+
         return (float(correct_n) / float(sample_n))
 
     def print_probalitity(self, prob_vec):

--- a/projects/semantic_selector/mysql.py
+++ b/projects/semantic_selector/mysql.py
@@ -2,6 +2,7 @@
 import os
 import mysql.connector
 import time
+import re
 import numpy as np
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
@@ -40,9 +41,27 @@ class InputTable(object):
             self.connect_info = connect_info
         self.exclude_threshold = exclude_threshold
         self.session = None
+        self.exclude_urls = [
+            'miu.ismedia.jp',
+            'www.ticket.kintetsu.co.jp',
+            'www.charge-net.co.jp',
+        ]
 
     def fetch_data(self):
-        return self.query()
+        data = self.query()
+        result = []
+        for d in data:
+            exclude = False
+            for pattern in self.exclude_urls:
+                if re.search(pattern, d.url):
+                    exclude = True
+            if d.canonical_topic == 'exclude':
+                exclude = True
+
+            if not exclude:
+                result.append(d)
+
+        return result
 
     def __get_session(self):
         if self.session is None:


### PR DESCRIPTION
# Overview

- add mechanism to exclude part of supervised data
   - based on url or
   - based on topic 

Note:
Due to ambiguity in topic labeling by human and the naming convention used in a certain web site, some url or some topic seems to be very difficult to infer the topic correctly.

# Related Links

- None

# TODO

- None